### PR TITLE
Refact tests to isolate response parse from specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,8 @@ require 'rspec/rails'
 require 'support/factory_bot'
 # Shoulda Matchers configuration file
 require 'support/shoulda_matchers'
+# Request Helpers import for specs
+require 'support/request_helpers'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -69,4 +71,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include RequestHelpers, type: :request
 end

--- a/spec/requests/user_request_spec.rb
+++ b/spec/requests/user_request_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe UsersController, type: :request do
       end
       it 'returns a user by id' do
         make_user_get_request_with_id
-        parsed_response = JSON.parse(response.body)
         expect(parsed_response['name']).to eq(user1.name)
       end
       it 'returns a right response for resume' do
@@ -38,7 +37,6 @@ RSpec.describe UsersController, type: :request do
         end
         it 'returns all created users' do
           make_user_get_request
-          parsed_response = JSON.parse(response.body)
           expect(parsed_response.size).to eq(3)
         end
       end
@@ -48,7 +46,6 @@ RSpec.describe UsersController, type: :request do
           it 'returns correct searched names' do
             make_user_get_request
             expect(response).to have_http_status(:ok)
-            parsed_response = JSON.parse(response.body)
             expect(parsed_response.size).to eq(1)
             expect(parsed_response.first['name']).to eq('Matheus')
           end
@@ -58,7 +55,6 @@ RSpec.describe UsersController, type: :request do
           it 'returns an empty list' do
             make_user_get_request
             expect(response).to have_http_status(:ok)
-            parsed_response = JSON.parse(response.body)
             expect(parsed_response.size).to eq(0)
           end
         end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,5 @@
+module RequestHelpers
+  def parsed_response
+    JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
Now JSON response parse is a method on `spec/support/request_helpers.rb`.
This method is used on specs preventing code repeating.