### PR TITLE
Creates role field for Users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -48,7 +48,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :cpf, :birthdate,
+    params.require(:user).permit(:name, :cpf, :birthdate, :role,
     profile_attributes: [ :image, :is_active ])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   validates :name, presence: true
   validates :cpf, presence: true
   validates :birthdate, presence: true
+  validates :role, inclusion: { in: %w[admin regular_user], message: "The 'role' param only accepts 'admin' and 'regular_user' values."  }
   has_one :profile, dependent: :destroy
   accepts_nested_attributes_for :profile
 

--- a/db/migrate/20250110121537_add_role_to_users.rb
+++ b/db/migrate/20250110121537_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_02_124722) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_10_121537) do
   create_table "profiles", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "image"
@@ -26,6 +26,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_02_124722) do
     t.date "birthdate"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "role"
   end
 
   add_foreign_key "profiles", "users"


### PR DESCRIPTION
Now Users can have a Role in the `role` field.
The valeu of `role` can be `admin` or `regular_user`.

PR changes:

1. Creates migration to add `role` to users table.
2. Implements validation to `role` values on users model, and if its not valid returns
`message: "The 'role' param only accepts 'admin' and 'regular_user' values."`.
3. Adds `role` to user_params on `UsersController`.
4. Adds specs for User model.
